### PR TITLE
Add parentheses to remove the ambiguity of deps and package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,8 +6,8 @@ defmodule Bencodex.Mixfile do
      version: "1.0.0",
      elixir: "~> 1.0",
      description: "Encoder and decoder for the bencode format",
-     package: package,
-     deps: deps]
+     package: package(),
+     deps: deps()]
   end
 
   def application do


### PR DESCRIPTION
In newer Elixir version you will get a warning like the following: 

`
warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
`

I added the parentheses to `packages` and `deps` to get rid of the warnings.